### PR TITLE
Added platform querystring

### DIFF
--- a/ios/App/AppDelegate.m
+++ b/ios/App/AppDelegate.m
@@ -31,7 +31,7 @@
    * on the same Wi-Fi network.
    */
 
-  jsCodeLocation = [NSURL URLWithString:@"http://localhost:8080/index.ios.bundle"];
+  jsCodeLocation = [NSURL URLWithString:@"http://localhost:8080/index.ios.bundle?platform=ios"];
 
   /**
    * OPTION 2


### PR DESCRIPTION
React native was failing with the following error `Error validating module options: child "platform" fails because ["platform" is required]`