### PR TITLE
Change buildToolsVersion to "23.0.2"

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -51,7 +51,7 @@ apply from: "react.gradle"
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         applicationId "com.app"


### PR DESCRIPTION
Change buildToolsVersion to "23.0.2".
* Improved the merging performance of the dx tool.
* Fixed issues in the RenderScript compiler for Windows.