### PR TITLE
Update build.gradle to use react native 0.20.+

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -74,5 +74,5 @@ android {
 dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
-    compile "com.facebook.react:react-native:0.19.+"
+    compile "com.facebook.react:react-native:0.20.+"
 }


### PR DESCRIPTION
I was running in to the issue talked about here: https://github.com/facebook/react-native/issues/5963

The fix, posted lower down was pretty simple, it seems that the react native version in the `package.json` and in Android's `build.grade` were out of sync. This should fix the issue.